### PR TITLE
Auth tokens

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,4 +2,4 @@ NODE_ENV=<probably=production>
 
 DATABASE_URL=<get from heroku>
 
-COOKIE_SECRET=<randomly_generated_string>
+SECRET=<randomly_generated_string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -693,6 +693,15 @@
       "resolved": "https://registry.npmjs.org/@types/jest-diff/-/jest-diff-20.0.1.tgz",
       "integrity": "sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA=="
     },
+    "@types/jsonwebtoken": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-8.3.5.tgz",
+      "integrity": "sha512-VGM1gb+LwsQ5EPevvbvdnKncajBdYqNcrvixBif1BsiDQiSF1q+j4bBTvKC6Bt9n2kqNSx+yNTY2TVJ360E7EQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/mime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
@@ -1268,6 +1277,11 @@
       "requires": {
         "node-int64": "^0.4.0"
       }
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -1866,6 +1880,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "editorconfig": {
@@ -4083,6 +4105,35 @@
         "minimist": "^1.2.0"
       }
     },
+    "jsonwebtoken": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
+      "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+      "requires": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^5.6.0"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+        }
+      }
+    },
     "jsprim": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
@@ -4092,6 +4143,25 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "kind-of": {
@@ -4184,6 +4254,36 @@
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
+    "lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
+    },
+    "lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
+    },
+    "lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.last": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lodash.last/-/lodash.last-3.0.0.tgz",
@@ -4193,6 +4293,11 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "express": "^5.0.0-alpha.7",
     "express-session": "1.16.2",
     "jest": "^24.9.0",
+    "jsonwebtoken": "^8.5.1",
     "node-postgres": "0.0.1",
     "pg": "7.12.1",
     "pm2": "3.5.1",
@@ -69,5 +70,8 @@
     "tslint": "5.20.0",
     "typescript": "3.6.3",
     "winston": "3.2.1"
+  },
+  "devDependencies": {
+    "@types/jsonwebtoken": "^8.3.5"
   }
 }

--- a/src/config/swagger.json
+++ b/src/config/swagger.json
@@ -34,6 +34,20 @@
       "description": "This is where to get information about invoice items from the database."
     }
   ],
+  "responses": {
+    "UnauthorizedError": {
+      "description": "JWT token not supplied or invalid header."
+    }
+  },
+  "parameters": {
+    "AuthToken": {
+      "name": "AuthToken",
+      "in": "header",
+      "description": "The JWT token that comes from /api/v1/login",
+      "required": true,
+      "type": "string"
+    }
+  },
   "paths": {
     "/login": {
       "get": {
@@ -72,9 +86,15 @@
         "responses": {
           "200": {
             "description": "This is the EntityID of the newly created entity."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "Name",
             "in": "query",
@@ -116,9 +136,15 @@
           },
           "400": {
             "description": "Bad request"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "EID",
             "in": "query",
@@ -139,9 +165,15 @@
           },
           "400": {
             "description": "Bad request"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "user",
             "in": "query",
@@ -165,9 +197,15 @@
           },
           "400": {
             "description": "Bad request or multiple invoices found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "InID",
             "in": "query",
@@ -183,9 +221,15 @@
         "responses": {
           "200": {
             "description": "This is the ID of the newly created invoice."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "DeliveryDate",
             "in": "query",
@@ -213,9 +257,15 @@
           },
           "404": {
             "description": "No invoices found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "EID",
             "in": "query",
@@ -236,9 +286,15 @@
           },
           "404": {
             "description": "No invoices found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "Name",
             "in": "query",
@@ -262,9 +318,15 @@
           },
           "400": {
             "description": "Bad request or multiple orders found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "OID",
             "in": "query",
@@ -280,9 +342,15 @@
         "responses": {
           "200": {
             "description": "This is the ID of the newly created order."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "SID",
             "in": "query",
@@ -334,9 +402,15 @@
           },
           "400": {
             "description": "Bad request or multiple orders found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "OID",
             "in": "query",
@@ -360,9 +434,15 @@
           },
           "400": {
             "description": "Bad request or multiple orders found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "OID",
             "in": "query",
@@ -383,9 +463,15 @@
           },
           "404": {
             "description": "No orders found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "EID",
             "in": "query",
@@ -406,9 +492,15 @@
           },
           "404": {
             "description": "No orders found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "EID",
             "in": "query",
@@ -429,9 +521,15 @@
           },
           "404": {
             "description": "No orders found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "EID",
             "in": "query",
@@ -459,9 +557,15 @@
           },
           "404": {
             "description": "No invoices found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "Name",
             "in": "query",
@@ -479,9 +583,15 @@
         "responses": {
           "200": {
             "description": "This is the updated order."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "OID",
             "in": "query",
@@ -506,9 +616,15 @@
         "responses": {
           "200": {
             "description": "This is the updated order."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "OID",
             "in": "query",
@@ -533,9 +649,15 @@
         "responses": {
           "200": {
             "description": "This is the updated order."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "OID",
             "in": "query",
@@ -566,9 +688,15 @@
           },
           "400": {
             "description": "Bad request or multiple items found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "IID",
             "in": "query",
@@ -584,9 +712,15 @@
         "responses": {
           "200": {
             "description": "This is the ID of the newly created item."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "Name",
             "in": "query",
@@ -621,9 +755,15 @@
           },
           "404": {
             "description": "No items found"
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "Name",
             "in": "query",
@@ -641,9 +781,15 @@
         "responses": {
           "200": {
             "description": "This is the newly created invoiceItems."
+          },
+          "401": {
+            "$ref": "#/responses/UnauthorizedError"
           }
         },
         "parameters": [
+          {
+            "$ref": "#/parameters/AuthToken"
+          },
           {
             "name": "InID",
             "in": "query",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,0 +1,34 @@
+import dotenv from "dotenv";
+import {NextFunction, Request, Response, Router} from "express";
+import * as jwt from "jsonwebtoken";
+
+dotenv.config();
+
+const verifyAuth = (req: Request, res: Response, next: NextFunction) => {
+    const token = req.headers.authtoken as string;
+    let jwtPayload;
+    try {
+        jwtPayload = jwt.verify(token, process.env.SECRET as string) as any;
+        res.locals.jwtPayload = jwtPayload;
+    } catch (err) {
+        // TODO: Should there be an HTTPError for this?
+        // unauthorized respond with a 401
+        res.status(401).send({msg: err.toString()});
+        return;
+    }
+
+    // Since the token expires in an hour, send a new one
+    const { username: name } = jwtPayload;
+    const newToken = jwt.sign(
+        {username: name},
+        process.env.SECRET as string,
+        {expiresIn: "1h"},
+    );
+    res.setHeader("token", newToken);
+
+    // Everything is good and we can continue
+    next();
+};
+
+export const handleAuthentication = (router: Router) =>
+    router.use(/\/api\/v1\/(?!login).*/, verifyAuth);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -24,7 +24,7 @@ const verifyAuth = (req: Request, res: Response, next: NextFunction) => {
         process.env.SECRET as string,
         {expiresIn: "1h"},
     );
-    res.setHeader("token", newToken);
+    res.setHeader("AuthToken", newToken);
 
     // Everything is good and we can continue
     next();

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -3,6 +3,7 @@
 *  */
 import {Router} from "express";
 import {handleAPIDocs} from "./apiDocs";
+import {handleAuthentication} from "./auth";
 import {
     handleBodyRequestParsing,
     handleCompression,
@@ -20,4 +21,5 @@ export default [
     handleAPIDocs,
     handleInfoLogger,
     // handleSession,
+    handleAuthentication,
 ] as MiddlewareHandler[];

--- a/src/services/Entity/QueryController.ts
+++ b/src/services/Entity/QueryController.ts
@@ -2,8 +2,10 @@
  * objects exported by this service. Some checks that are used exclusively by the UserService are also defined here.
  * */
 
+import dotenv from "dotenv";
 import {NextFunction, Request, Response} from "express";
-import {checkAscii, checkDate} from "../../utils/checks";
+import * as jwt from "jsonwebtoken";
+import {checkAscii} from "../../utils/checks";
 import {Entity} from "../../utils/dbTypes";
 import {HTTP400Error} from "../../utils/httpErrors";
 import {createEntity} from "./providers/createEntityRequest";
@@ -11,12 +13,26 @@ import {getEntityByEntityID} from "./providers/entityByIDRequest";
 import {getEntityByEntityName} from "./providers/entityByNameRequest";
 import {loginRequest} from "./providers/loginRequest";
 
+dotenv.config();
+
+interface ILoginResponse extends Entity {
+    token: string;
+}
+
 export const setEntity = async (ent: Entity) => {
     return createEntity(ent);
 };
 
 export const getLogin = async  (name: string, pass: string) => {
-    return await loginRequest(name, pass);
+    // Send the jwt in the response
+    const res: ILoginResponse = await loginRequest(name, pass) as ILoginResponse;
+
+    res.token = jwt.sign(
+        {username: name},
+        process.env.SECRET as string,
+        {expiresIn: "1h"},
+    );
+    return res;
 };
 
 export const getEntityByID = async (EID: number) => {


### PR DESCRIPTION
This pull request will enable and __require__ JWT auth tokens on all endpoints that are not `/api/v1/login`. To support auth tokens, you need to:

- [ ] Store auth tokens in cookie information (they only last an hour).
- [ ] If there is no auth token, redirect the user to the login page.
- [ ] Every time a request is made to a non login endpoint, put a valid auth token in the `AuthToken` field of the header of the request.
- [ ] On every request, a new auth token will be returned in the `AuthToken` field of the response. You need to refresh the auth token in the cookie so that the current auth token does not time out.